### PR TITLE
Fixes the unit tests in Moodle/Totara.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ env:
 matrix:
   include:
     # Test with MySQL
-    - php: 7.1
+    - php: 7.3
       env: DB=mysqli MOODLE_BRANCH=master
-    # Test with PHP 7.1
-    - php: 7.1
+    # Test with PHP 7.3
+    - php: 7.3
       env: MOODLE_BRANCH=master
   exclude:
     - php: 7.3
@@ -45,9 +45,14 @@ matrix:
       env: MOODLE_BRANCH=MOODLE_35_STABLE
 
 before_install:
+  - export MOODLE_VERSION=$(echo "$MOODLE_BRANCH" | cut -d'_' -f 2)
+  - phpenv config-rm xdebug.ini
+  - if [ "$MOODLE_VERSION" = 36 ] || [ "$MOODLE_VERSION" -le 34 ]; then NVMVERSION=8.9; else NVMVERSION=14.0.0; fi
+  - nvm install $NVMVERSION;
+  - nvm use $NVMVERSION;
   - cd ../..
   - composer selfupdate
-  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^1
+  - composer create-project -n --no-dev moodlerooms/moodle-plugin-ci ci ^2
   - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
 
 install:
@@ -58,13 +63,13 @@ install:
     fi
 
 script:
-  - moodle-plugin-ci validate
   - moodle-plugin-ci phplint
   - moodle-plugin-ci phpcpd
   - moodle-plugin-ci phpmd
   - moodle-plugin-ci codechecker
-  - moodle-plugin-ci csslint
-  - moodle-plugin-ci shifter
-  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci savepoints
+  - moodle-plugin-ci mustache
+  - moodle-plugin-ci grunt
   - moodle-plugin-ci phpunit
   - moodle-plugin-ci behat

--- a/lib.php
+++ b/lib.php
@@ -47,7 +47,7 @@ function tool_passwordvalidator_check_password_policy($password, $user = null) {
 /**
  * Function for the printing of the password policy
  *
- * @return string Returns a string of any errors presented by the checks, or an empty string for success.
+ * @return array Returns an array with a string of any errors presented by the checks, or an empty string for success.
  *
  */
 function tool_passwordvalidator_print_password_policy() {
@@ -55,13 +55,13 @@ function tool_passwordvalidator_print_password_policy() {
         // Check for templates being active
         $template = get_config('tool_passwordvalidator', 'chosen_template');
         if ($template != '') {
-            return get_string("passwordpolicy$template", 'tool_passwordvalidator');
+            return [get_string("passwordpolicy$template", 'tool_passwordvalidator')];
         } else {
             // Inform no template use
-            return get_string('passwordpolicynotemplate', 'tool_passwordvalidator');
+            return [get_string('passwordpolicynotemplate', 'tool_passwordvalidator')];
         }
     } else {
         // Return empty, 'no current policy enabled
-        return '';
+        return [];
     }
 }


### PR DESCRIPTION
With https://tracker.moodle.org/browse/MDL-66278 applied, it expects that the return value for the function hook print_password_policy must return an array of strings. https://github.com/moodle/moodle/blob/master/lib/weblib.php#L3638

M: core_weblib_testcase, test_print_password_policy.
T: auth_approved_auth_testcase, test_basic_auth_structure.